### PR TITLE
fix: Resolved Discrepancy in Compare Label Display

### DIFF
--- a/src/date-range-picker.tsx
+++ b/src/date-range-picker.tsx
@@ -328,42 +328,45 @@ export const DateRangePicker: FC<DateRangePickerProps> & {
                 <div className="flex items-center space-x-2 pr-4 py-1">
                   {
                     showCompare && (
-                    <Switch
-                      defaultChecked={Boolean(rangeCompare)}
-                      onCheckedChange={(checked: boolean) => {
-                        if (checked) {
-                          if (!range.to) {
-                            setRange({
-                              from: range.from,
-                              to: range.from
-                            })
-                          }
-                          setRangeCompare({
-                            from: new Date(
-                              range.from.getFullYear(),
-                              range.from.getMonth(),
-                              range.from.getDate() - 365
-                            ),
-                            to: range.to
-                              ? new Date(
-                                range.to.getFullYear() - 1,
-                                range.to.getMonth(),
-                                range.to.getDate()
-                              )
-                              : new Date(
-                                range.from.getFullYear() - 1,
+                      <>
+                      <Switch
+                        defaultChecked={Boolean(rangeCompare)}
+                        onCheckedChange={(checked: boolean) => {
+                          if (checked) {
+                            if (!range.to) {
+                              setRange({
+                                from: range.from,
+                                to: range.from
+                              })
+                            }
+                            setRangeCompare({
+                              from: new Date(
+                                range.from.getFullYear(),
                                 range.from.getMonth(),
-                                range.from.getDate()
-                              )
-                          })
-                        } else {
-                          setRangeCompare(undefined)
-                        }
-                      }}
-                      id="compare-mode"
-                    />
+                                range.from.getDate() - 365
+                              ),
+                              to: range.to
+                                ? new Date(
+                                  range.to.getFullYear() - 1,
+                                  range.to.getMonth(),
+                                  range.to.getDate()
+                                )
+                                : new Date(
+                                  range.from.getFullYear() - 1,
+                                  range.from.getMonth(),
+                                  range.from.getDate()
+                                )
+                            })
+                          } else {
+                            setRangeCompare(undefined)
+                          }
+                        }}
+                        id="compare-mode"
+                      />
+                      <Label htmlFor="compare-mode">Compare</Label>
+                    </>
                     )}
-                  <Label htmlFor="compare-mode">Compare</Label>
+                  
                 </div>
                 <div className="flex flex-col gap-2">
                   <div className="flex gap-2">


### PR DESCRIPTION
In this commit, I have addressed an issue related to label visibility when the showCompare flag is set to false. Previously, there was a discrepancy where the compare label was still visible despite the flag being turned off. With this fix, the compare label will now correctly remain hidden when the showCompare flag is set to false, ensuring consistent behavior in accordance with user expectations. This improvement enhances the accuracy and reliability of our application's label display functionality.
