### PR TITLE
Fix Date Mutation in checkPreset Function

### DIFF
--- a/src/date-range-picker.tsx
+++ b/src/date-range-picker.tsx
@@ -207,12 +207,14 @@ export const DateRangePicker: FC<DateRangePickerProps> & {
     for (const preset of PRESETS) {
       const presetRange = getPresetRange(preset.name)
 
-      const normalizedRangeFrom = new Date(range.from.setHours(0, 0, 0, 0))
+      const normalizedRangeFrom = new Date(range.from);
+      normalizedRangeFrom.setHours(0, 0, 0, 0);
       const normalizedPresetFrom = new Date(
         presetRange.from.setHours(0, 0, 0, 0)
       )
 
-      const normalizedRangeTo = new Date(range.to?.setHours(0, 0, 0, 0) ?? 0)
+      const normalizedRangeTo = new Date(range.to ?? 0);
+      normalizedRangeTo.setHours(0, 0, 0, 0);
       const normalizedPresetTo = new Date(
         presetRange.to?.setHours(0, 0, 0, 0) ?? 0
       )


### PR DESCRIPTION
This pull request addresses a critical issue in the checkPreset function where the original values of range.from and range.to were being unintentionally mutated. Previously, the function directly modified these Date objects by calling setHours(0, 0, 0, 0) on them. This behavior was leading to side effects, as the range object's from and to values were altered globally, affecting other parts of the application relying on these values.

**Changes Made:**

Modified the checkPreset function to prevent mutation of the original range.from and range.to values.
Implemented creation of new Date objects (normalizedRangeFrom and normalizedRangeTo) based on the existing range.from and range.to before setting their hours to midnight. This ensures that the original range object remains unchanged after the function's execution.
Impact:

The updates ensure that the checkPreset function now performs its intended check without causing unintended side effects in other parts of the application.
Improves the reliability of date comparisons in the function, ensuring that the preset selection logic is more robust and error-free.